### PR TITLE
Dolby: Set defaultValue to prevent crash when disabled

### DIFF
--- a/dolby/res/xml/dolby_settings.xml
+++ b/dolby/res/xml/dolby_settings.xml
@@ -38,6 +38,7 @@
             android:key="dolby_ieq"
             android:entries="@array/dolby_ieq_entries"
             android:entryValues="@array/dolby_ieq_values"
+            android:defaultValue="0"
             android:title="@string/dolby_ieq" />
 
         <SwitchPreferenceCompat


### PR DESCRIPTION
Dolby: Set defaultValue to prevent crash when disabled

Fix a crash in Dolby settings that occurred when Dolby was fully turned off. The preference was missing a valid default, causing a Resources$NotFoundException (Resource ID #0x0).
Adding android:defaultValue="0" ensures a safe fallback.